### PR TITLE
Update IPFS codec registration example

### DIFF
--- a/example-ipfs-legacy.mjs
+++ b/example-ipfs-legacy.mjs
@@ -3,6 +3,7 @@ import { generateKeyPairFromSeed } from '@stablelib/x25519'
 
 // IPLD & IPFS
 import { create as createIpfs } from 'ipfs'
+import { convert as toLegacyIpld } from 'blockcodec-to-ipld-format'
 
 // JWT & utilities
 import {
@@ -20,13 +21,15 @@ import {
 
 import * as dagJose from './lib/index.js'
 
+// Translate DAG-JOSE into the IPLD interface js-IPFS understands
+const dagJoseIpldFormat = toLegacyIpld(dagJose)
 let ipfs
 
 // Async setup tasks
 async function setup () {
   console.log('Starting IPFS ...')
   // Instantiate an IPFS node, that knows how to deal with DAG-JOSE blocks
-  ipfs = await createIpfs({ ipld: { codecs: [dagJose] } })
+  ipfs = await createIpfs({ ipld: { formats: [dagJoseIpldFormat] } })
 }
 
 async function symmetric () {
@@ -38,7 +41,7 @@ async function symmetric () {
     // encrypt into JWE container layout using secret key
     const jwe = await createJWE(cleartext, [dirEncrypter])
     // let IPFS store the bytes using the DAG-JOSE codec and return a CID
-    const cid = await ipfs.dag.put(jwe, { format: 'dag-jose', hashAlg: 'sha2-256' })
+    const cid = await ipfs.dag.put(jwe, { format: dagJoseIpldFormat.codec, hashAlg: 'sha2-256' })
     console.log(`Encrypted block CID: \u001b[32m${cid}\u001b[39m`)
     return cid
   }
@@ -69,7 +72,7 @@ async function asymmetric () {
     // encrypt into JWE container layout using public key
     const jwe = await createJWE(cleartext, [asymEncrypter])
     // let IPFS store the bytes using the DAG-JOSE codec and return a CID
-    const cid = await ipfs.dag.put(jwe, { format: 'dag-jose', hashAlg: 'sha2-256' })
+    const cid = await ipfs.dag.put(jwe, { format: dagJoseIpldFormat.codec, hashAlg: 'sha2-256' })
     console.log(`Encrypted block CID: \u001b[32m${cid}\u001b[39m`)
     return cid
   }


### PR DESCRIPTION
Update documentation to reflect that versions of js-IPFS greater than 0.40 support direct usage of multiformats codecs.