### PR TITLE
fix: pin multiformats to patches of v13.1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "dag-jose",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dag-jose",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
-        "multiformats": "^13.1.0"
+        "multiformats": "~13.1.3"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -8165,9 +8165,9 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.3.tgz",
+      "integrity": "sha512-CZPi9lFZCM/+7oRolWYsvalsyWQGFo+GpdaTmjxXXomC+nP/W1Rnxb9sUgjvmNmRZ5bOPqRAl4nuK+Ydw/4tGw=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dag-jose",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Typescript implementation of the IPLD dag-jose format",
   "main": "./lib/index.js",
   "type": "module",
@@ -59,6 +59,6 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "^9.0.0",
-    "multiformats": "^13.1.0"
+    "multiformats": "~13.1.3"
   }
 }


### PR DESCRIPTION
Pinning multiformats version to 13.1.x because the latest release (13.2.0) broke our builds.